### PR TITLE
POC - update authUrl

### DIFF
--- a/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
+++ b/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
@@ -197,7 +197,7 @@ public class KeycloakInstalled {
         CallbackListener callback = new CallbackListener();
         callback.start();
 
-        String redirectUri = String.format("http://%s:%s", getListenHostname(), callback.getLocalPort());
+        String redirectUri = String.format("https://%s:%s", getListenHostname(), callback.getLocalPort());
         String state = UUID.randomUUID().toString();
         Pkce pkce = deployment.isPkce() ? generatePkce() : null;
 


### PR DESCRIPTION
- Updates `authURL` to use `https` instead of `http` to resolve the Keycloak JS issue not being downloaded when accessing the admin console via `https`